### PR TITLE
Add sprintf logging functions

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -101,6 +101,26 @@ func (logger *Logger) Info(message string) {
 	logger.logLine(message, infoPrefix, infoPrefixColored, logger.infoLogFile)
 }
 
+func (logger *Logger) Criticalf(message string, a ...any) {
+	logger.logLine(fmt.Sprintf(message, a...), criticalPrefix, criticalPrefixColored, logger.criticalLogFile)
+}
+
+func (logger *Logger) Errorf(message string, a ...any) {
+	logger.logLine(fmt.Sprintf(message, a...), errorPrefix, errorPrefixColored, logger.errorLogFile)
+}
+
+func (logger *Logger) Warningf(message string, a ...any) {
+	logger.logLine(fmt.Sprintf(message, a...), warningPrefix, warningPrefixColored, logger.warningLogFile)
+}
+
+func (logger *Logger) Successf(message string, a ...any) {
+	logger.logLine(fmt.Sprintf(message, a...), successPrefix, successPrefixColored, logger.successLogFile)
+}
+
+func (logger *Logger) Infof(message string, a ...any) {
+	logger.logLine(fmt.Sprintf(message, a...), infoPrefix, infoPrefixColored, logger.infoLogFile)
+}
+
 func NewLogger(args ...string) *Logger {
 	var logFolderRoot string
 

--- a/logger.go
+++ b/logger.go
@@ -102,23 +102,23 @@ func (logger *Logger) Info(message string) {
 }
 
 func (logger *Logger) Criticalf(message string, a ...any) {
-	logger.logLine(fmt.Sprintf(message, a...), criticalPrefix, criticalPrefixColored, logger.criticalLogFile)
+	logger.Critical(fmt.Sprintf(message, a...))
 }
 
 func (logger *Logger) Errorf(message string, a ...any) {
-	logger.logLine(fmt.Sprintf(message, a...), errorPrefix, errorPrefixColored, logger.errorLogFile)
+	logger.Error(fmt.Sprintf(message, a...))
 }
 
 func (logger *Logger) Warningf(message string, a ...any) {
-	logger.logLine(fmt.Sprintf(message, a...), warningPrefix, warningPrefixColored, logger.warningLogFile)
+	logger.Warning(fmt.Sprintf(message, a...))
 }
 
 func (logger *Logger) Successf(message string, a ...any) {
-	logger.logLine(fmt.Sprintf(message, a...), successPrefix, successPrefixColored, logger.successLogFile)
+	logger.Success(fmt.Sprintf(message, a...))
 }
 
 func (logger *Logger) Infof(message string, a ...any) {
-	logger.logLine(fmt.Sprintf(message, a...), infoPrefix, infoPrefixColored, logger.infoLogFile)
+	logger.Info(fmt.Sprintf(message, a...))
 }
 
 func NewLogger(args ...string) *Logger {

--- a/logger_test.go
+++ b/logger_test.go
@@ -23,3 +23,23 @@ func TestSuccessLog(t *testing.T) {
 func TestInfoLog(t *testing.T) {
 	logger.Info("Info")
 }
+
+func TestCritialfLog(t *testing.T) {
+	logger.Criticalf("Critical errorf: %s, %t, %d", "I'm a string", false, 42)
+}
+
+func TestErrorfLog(t *testing.T) {
+	logger.Errorf("Errorf: %s, %t, %d", "I'm a string", false, 42)
+}
+
+func TestWarningfLog(t *testing.T) {
+	logger.Warningf("Warningf: %s, %t, %d", "I'm a string", false, 42)
+}
+
+func TestSuccessfLog(t *testing.T) {
+	logger.Successf("Successf: %s, %t, %d", "I'm a string", false, 42)
+}
+
+func TestInfofLog(t *testing.T) {
+	logger.Infof("Infof: %s, %t, %d", "I'm a string", false, 42)
+}


### PR DESCRIPTION
This PR adds the ability to log with `sprintf` formatting without having to do it yourself every time.
It also adds some tests for them as well.