### PR TITLE
Revert "Simplify flogs"

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -102,23 +102,23 @@ func (logger *Logger) Info(message string) {
 }
 
 func (logger *Logger) Criticalf(message string, a ...any) {
-	logger.Critical(fmt.Sprintf(message, a...))
+	logger.logLine(fmt.Sprintf(message, a...), criticalPrefix, criticalPrefixColored, logger.criticalLogFile)
 }
 
 func (logger *Logger) Errorf(message string, a ...any) {
-	logger.Error(fmt.Sprintf(message, a...))
+	logger.logLine(fmt.Sprintf(message, a...), errorPrefix, errorPrefixColored, logger.errorLogFile)
 }
 
 func (logger *Logger) Warningf(message string, a ...any) {
-	logger.Warning(fmt.Sprintf(message, a...))
+	logger.logLine(fmt.Sprintf(message, a...), warningPrefix, warningPrefixColored, logger.warningLogFile)
 }
 
 func (logger *Logger) Successf(message string, a ...any) {
-	logger.Success(fmt.Sprintf(message, a...))
+	logger.logLine(fmt.Sprintf(message, a...), successPrefix, successPrefixColored, logger.successLogFile)
 }
 
 func (logger *Logger) Infof(message string, a ...any) {
-	logger.Info(fmt.Sprintf(message, a...))
+	logger.logLine(fmt.Sprintf(message, a...), infoPrefix, infoPrefixColored, logger.infoLogFile)
 }
 
 func NewLogger(args ...string) *Logger {


### PR DESCRIPTION
This simplification of duplicate code worsens the logs produced, because it treats `logger.Errorf()` as the caller function for the log, instead of the function that calls the log.

Before: 
![imagen](https://github.com/PretendoNetwork/plogger-go/assets/112760654/4bf28654-e5a3-4231-9b75-cdc489838c37)


After: 
![imagen](https://github.com/PretendoNetwork/plogger-go/assets/112760654/ca33700b-d84f-4bb7-931c-32efc391a312)


This reverts commit 135ed7a09a1caeeb96a224a1a75d5bb25178b3f8.