### PR TITLE
Add log levels

### DIFF
--- a/log_level.go
+++ b/log_level.go
@@ -1,0 +1,7 @@
+package plogger
+
+type logLevel uint8
+
+const (
+	LogLevelDebug logLevel = 0
+)

--- a/logger.go
+++ b/logger.go
@@ -50,6 +50,7 @@ var (
 )
 
 type Logger struct {
+	LogLevel        logLevel
 	allLogsFile     *os.File
 	criticalLogFile *os.File
 	errorLogFile    *os.File


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds log levels to the logger. Currently not implemented, only the `logLevel` type is added since I wanted to discuss the best way to actually use these log levels. The `logLevel` type is not exported because it's purely internal, external packages don't need it

This is done to try to address an issue jvs mentioned on Discord:

> also if somebody is interesting in improving nex servers. every game server still eats up a couple thousand log lines with useless info
> William even combined the 4 log lines (equal signs, protocol id, method id, more equal signs) into 1. and its still 1.3 million in 24h

The logs in question being the logs like this which are seen in many servers https://github.com/PretendoNetwork/super-mario-maker/blob/4edd248eea7d719655467a43e8161da47513fb77/nex/secure.go#L26-L33

The information was used during development for debugging, but isn't SUPER useful in production. Putting this kind of thing behind a `LogLevelDebug` or `LogLevelDevelopment`, which is not set in production, should fix this

CC @DaniElectra for thoughts. Draft for now since the PR is useless as-is

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.